### PR TITLE
Returns an early error if decryption fails

### DIFF
--- a/command.go
+++ b/command.go
@@ -854,6 +854,9 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 	// RC: Implementation of decryption - use DI to test
 	decryptor := decryptor.NewDecryptor()
 	flags, err = decryptor.DecryptArguments(flags)
+	if err != nil {
+		return cmd, err
+	}
 
 	err = cmd.execute(flags)
 	if err != nil {


### PR DESCRIPTION
## Description
We were not handling the decryption error, which could lead to confusion if a command were to fail.